### PR TITLE
updated guzzle version to work with laravel 8 - fixes #1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   ],
   "require": {
     "php": ">=5.5.0",
-    "guzzlehttp/guzzle": "^6.0"
+    "guzzlehttp/guzzle": "^6.0|^7.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.0"


### PR DESCRIPTION
It's not possible to use this client with Laravel 8, because laravel depends on 7.0 version of guzzle and this library fixes the dependency in the version 6.0. But the two versions are very compatible, with the major difference been the PHP version supported.

This PR closes #1 